### PR TITLE
fix: Update vite.config.ts base path for GitHub Pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig(({ mode }) => {
       // IMPORTANTE: Substitua 'repository-name' pelo nome do seu repositório no GitHub.
       // Exemplo: se o seu repositório for 'https://github.com/user/my-app',
       // o 'base' deve ser '/my-app/'.
-      base: '/repository-name/',
+      base: '/pequenospassos/',
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
         'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)


### PR DESCRIPTION
Updated the `base` path in `vite.config.ts` to `/pequenospassos/` to match the repository name. This is necessary for the correct deployment to GitHub Pages, as it ensures that all assets are loaded from the correct path.