### PR TITLE
I've fixed the CSS path and the DOMPurify integrity hash. Here's a br…

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,8 @@
     <!-- Google Material Symbols -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
     <!-- DOMPurify -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.1.6/purify.min.js" integrity="sha512-T2u8r0zOC0pG07j81pcWvRMjrbV5Fe3vL5kO16e6+z3X3doP7a2BOCFOT0VhJ3cH3G/U1kaV5FXk2bENQ3+QSNA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <link rel="stylesheet" href="index.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.1.6/purify.min.js" integrity="sha512-jB0TkTBeQC9ZSkBqDhdmfTv1qdfbWpGE72yJ/01Srq6hEzZIz2xkz1e57p9ai7IeHMwEG7HpzG6NdptChif5Pg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <link rel="stylesheet" href="./index.css">
     <script type="importmap">
 {
   "imports": {
@@ -20,7 +20,6 @@
   }
 }
 </script>
-<link rel="stylesheet" href="/index.css">
 </head>
 <body class="sidebar-collapsed"> <!-- Default to collapsed, JS will adjust based on screen/localStorage -->
 


### PR DESCRIPTION
…eakdown of the changes:

- I consolidated the two `<link>` tags for `index.css` into a single tag with a relative path (`./index.css`) to ensure it's loaded correctly on GitHub Pages.
- I updated the `integrity` hash for the DOMPurify script to match the version being loaded, which resolves the Subresource Integrity (SRI) check failure.