### PR TITLE
fix: Use relative path for index.tsx script

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,6 +161,6 @@
     <!-- Toast Notification Container -->
     <div id="toast-notification-container" aria-live="assertive" aria-atomic="true"></div>
 
-<script type="module" src="/index.tsx"></script>
+<script type="module" src="./index.tsx"></script>
 </body>
 </html>


### PR DESCRIPTION
Changed the `src` attribute of the `<script>` tag for `index.tsx` from an absolute path (`/index.tsx`) to a relative path (`./index.tsx`). This ensures that the script is loaded correctly when the site is deployed to a subdirectory on GitHub Pages.