### PR TITLE
Fix: Ensure app works on GitHub Pages

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -13,6 +13,7 @@ import { setupSocialPage, showSocialPage } from './social';
 import { setupPlanejamentoDiarioPage, showPlanejamentoDiarioPage } from './planejamento-diario';
 import { setupTarefasPage, showTarefasPage } from './tarefas';
 import { setupAlongamentoPage, showAlongamentoPage } from './alongamento';
+import { setupInicioPage, showInicioPage } from './inicio';
 import DOMPurify from 'dompurify';
 
 // Re-declare the global window interface to inform TypeScript about global functions
@@ -823,6 +824,7 @@ const pageModules: { [key: string]: { setup: () => void; show: () => void; } } =
     'planejamento-diario': { setup: setupPlanejamentoDiarioPage, show: showPlanejamentoDiarioPage },
     'tarefas': { setup: setupTarefasPage, show: showTarefasPage },
     'alongamento': { setup: setupAlongamentoPage, show: showAlongamentoPage },
+    'inicio': { setup: setupInicioPage, show: showInicioPage },
 };
 
 
@@ -951,7 +953,7 @@ document.addEventListener('DOMContentLoaded', () => {
             pageToLoad = hash;
         } 
         // 2. Is it a static content page with a specific pattern?
-        else if (hash.startsWith('leitura-guia-') || hash.startsWith('food-') || hash === 'inicio' || hash === 'jejum-verde' || hash === 'alimentacao-forte') {
+        else if (hash.startsWith('leitura-guia-') || hash.startsWith('food-') || hash === 'jejum-verde' || hash === 'alimentacao-forte') {
             pageToLoad = hash;
         } 
         // 3. If not a direct page, assume it's an anchor within another page.

--- a/package-lock.json
+++ b/package-lock.json
@@ -762,6 +762,7 @@
       "integrity": "sha512-2Q7WS25j4pS1cS8yw3d6buNCVJukOTeQ39bAnwR6sOJbaxvyCGebzTMypDFN82CxBLnl+lSWVdCCWbRY6y9yZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1248,6 +1249,7 @@
       "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig(({ mode }: ConfigEnv): UserConfig => {
     const env = loadEnv(mode, '.', '');
 
     return {
+      base: './',
       plugins: [basicSsl()],
       define: {
         // Standardize on using API_KEY from the environment.


### PR DESCRIPTION
- Set `base: './'` in `vite.config.ts` to use relative paths for assets, fixing the blank page issue on GitHub Pages deployments.
- Registered `inicio` in `pageModules` in `index.tsx` to ensure the home page is correctly initialized by the router.
- Removed `inicio` from the static router fallback.